### PR TITLE
FEATURE/product/kafa기능구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencyManagement {
 
 dependencies {
 	// 공통 모듈
-	implementation 'com.ezmeal:common:0.0.4'
+	implementation 'com.ezmeal:common:0.0.5'
 
 	//querydsl
 	annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'

--- a/src/main/java/com/ezmeal/product/application/ProductService.java
+++ b/src/main/java/com/ezmeal/product/application/ProductService.java
@@ -6,6 +6,10 @@ import com.ezmeal.product.application.request.ProductMealPlanCreateRequest;
 import com.ezmeal.product.application.request.ProductMealPlanUpdateRequest;
 import com.ezmeal.product.application.request.ProductUpdateRequest;
 import com.ezmeal.product.application.response.ProductResponse;
+import com.ezmeal.product.domain.event.payload.ProductCreatedEvent;
+import com.ezmeal.product.domain.event.payload.ProductDeletedEvent;
+import com.ezmeal.product.domain.event.payload.ProductMealPlanEventPayload;
+import com.ezmeal.product.domain.event.payload.ProductUpdatedEvent;
 import com.ezmeal.product.domain.exception.ProductErrorCode;
 import com.ezmeal.product.domain.model.Product;
 import com.ezmeal.product.domain.model.ProductMealPlan;
@@ -14,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,7 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ProductService {
     private final ProductRepository productRepository;
-
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     //상품 생성
     @Transactional
@@ -47,6 +52,18 @@ public class ProductService {
             product.addMealPlan(mealPlan);
         }
         Product productSaved = productRepository.save(product);
+
+        List<ProductMealPlanEventPayload> mealPlans = productSaved.getMealPlans().stream()
+                .map(ProductMealPlanEventPayload::from)
+                .toList();
+
+        ProductCreatedEvent event = ProductCreatedEvent.of(productSaved.getId(), productSaved.getCompanyId(),
+                productSaved.getName(),
+                productSaved.getDescription(),
+                productSaved.getPrice(), productSaved.getCategory(), productSaved.getMealPeriod(),
+                productSaved.getMaxOrderCount(), mealPlans
+        );
+        applicationEventPublisher.publishEvent(event);
 
         return ProductResponse.from(productSaved);
     }
@@ -83,6 +100,17 @@ public class ProductService {
             product.replaceMealPlans(newMealPlans);
         }
 
+        List<ProductMealPlanEventPayload> mealPlans = product.getMealPlans().stream()
+                .map(ProductMealPlanEventPayload::from)
+                .toList();
+
+        ProductUpdatedEvent event = ProductUpdatedEvent.of(product.getId(), product.getCompanyId(), product.getName(),
+                product.getDescription(),
+                product.getPrice(), product.getCategory(), product.getMealPeriod(), product.getMaxOrderCount(),
+                mealPlans
+        );
+        applicationEventPublisher.publishEvent(event);
+
         return ProductResponse.from(product);
     }
 
@@ -94,6 +122,9 @@ public class ProductService {
                 .orElseThrow(() -> new CustomException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
         product.delete(deletedBy);
+
+        ProductDeletedEvent event = ProductDeletedEvent.of(product.getId(), product.getCompanyId());
+        applicationEventPublisher.publishEvent(event);
     }
 
     //단건 조회

--- a/src/main/java/com/ezmeal/product/application/event/ProductKafkaListener.java
+++ b/src/main/java/com/ezmeal/product/application/event/ProductKafkaListener.java
@@ -1,0 +1,35 @@
+package com.ezmeal.product.application.event;
+
+import com.ezmeal.product.domain.event.ProductEventProducer;
+import com.ezmeal.product.domain.event.payload.ProductCreatedEvent;
+import com.ezmeal.product.domain.event.payload.ProductDeletedEvent;
+import com.ezmeal.product.domain.event.payload.ProductUpdatedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class ProductKafkaListener {
+
+    private final ProductEventProducer productEventProducer;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleProductCreatedEvent(ProductCreatedEvent event) {
+        productEventProducer.publishCreatedEvent(event);
+    }
+
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleProductUpdatedEvent(ProductUpdatedEvent event) {
+        productEventProducer.publishUpdatedEvent(event);
+    }
+
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleProductDeletedEvent(ProductDeletedEvent event) {
+        productEventProducer.publishDeletedEvent(event);
+    }
+
+}

--- a/src/main/java/com/ezmeal/product/domain/event/ProductEventProducer.java
+++ b/src/main/java/com/ezmeal/product/domain/event/ProductEventProducer.java
@@ -1,0 +1,13 @@
+package com.ezmeal.product.domain.event;
+
+import com.ezmeal.product.domain.event.payload.ProductCreatedEvent;
+import com.ezmeal.product.domain.event.payload.ProductDeletedEvent;
+import com.ezmeal.product.domain.event.payload.ProductUpdatedEvent;
+
+public interface ProductEventProducer {
+    void publishCreatedEvent(ProductCreatedEvent event);
+
+    void publishUpdatedEvent(ProductUpdatedEvent event);
+
+    void publishDeletedEvent(ProductDeletedEvent event);
+}

--- a/src/main/java/com/ezmeal/product/domain/event/ProductEventType.java
+++ b/src/main/java/com/ezmeal/product/domain/event/ProductEventType.java
@@ -1,0 +1,7 @@
+package com.ezmeal.product.domain.event;
+
+public enum ProductEventType {
+    PRODUCT_CREATED,
+    PRODUCT_UPDATED,
+    PRODUCT_DELETED
+}

--- a/src/main/java/com/ezmeal/product/domain/event/payload/ProductCreatedEvent.java
+++ b/src/main/java/com/ezmeal/product/domain/event/payload/ProductCreatedEvent.java
@@ -1,0 +1,44 @@
+package com.ezmeal.product.domain.event.payload;
+
+import com.ezmeal.product.domain.event.ProductEventType;
+import com.ezmeal.product.domain.model.ProductCategory;
+import com.ezmeal.product.domain.model.ProductMealPeriod;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ProductCreatedEvent {
+
+    private UUID eventId;
+    private ProductEventType productEventType;
+    private OffsetDateTime occurredAt;
+    private UUID productId;
+    private UUID companyId;
+    private String productName;
+    private String productDescription;
+    private Integer price;
+    private ProductCategory category;
+    private ProductMealPeriod mealPeriod;
+    private Integer maxOrderCount;
+    private List<ProductMealPlanEventPayload> mealPlans;
+
+    public static ProductCreatedEvent of(UUID productId, UUID companyId, String productName, String productDescription,
+                                         Integer price,
+                                         ProductCategory category, ProductMealPeriod mealPeriod, Integer maxOrderCount,
+                                         List<ProductMealPlanEventPayload> mealPlans
+    ) {
+        return new ProductCreatedEvent(UUID.randomUUID(),
+                ProductEventType.PRODUCT_CREATED,
+                OffsetDateTime.now(), productId, companyId, productName, productDescription, price, category,
+                mealPeriod,
+                maxOrderCount, mealPlans);
+    }
+
+}

--- a/src/main/java/com/ezmeal/product/domain/event/payload/ProductDeletedEvent.java
+++ b/src/main/java/com/ezmeal/product/domain/event/payload/ProductDeletedEvent.java
@@ -1,0 +1,28 @@
+package com.ezmeal.product.domain.event.payload;
+
+import com.ezmeal.product.domain.event.ProductEventType;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ProductDeletedEvent {
+
+    private UUID eventId;
+    private ProductEventType productEventType;
+    private OffsetDateTime occurredAt;
+    private UUID productId;
+    private UUID companyId;
+
+    public static ProductDeletedEvent of(UUID productId, UUID companyId
+    ) {
+        return new ProductDeletedEvent(UUID.randomUUID(),
+                ProductEventType.PRODUCT_DELETED,
+                OffsetDateTime.now(), productId, companyId);
+    }
+}

--- a/src/main/java/com/ezmeal/product/domain/event/payload/ProductMealPlanEventPayload.java
+++ b/src/main/java/com/ezmeal/product/domain/event/payload/ProductMealPlanEventPayload.java
@@ -1,0 +1,23 @@
+package com.ezmeal.product.domain.event.payload;
+
+import com.ezmeal.product.domain.model.ProductMealPlan;
+import java.time.DayOfWeek;
+import java.util.UUID;
+
+public record ProductMealPlanEventPayload(
+        UUID mealPlanId,
+        DayOfWeek dayOfWeek,
+        String menuName,
+        String allergyInfo,
+        String nutritionInfo
+) {
+    public static ProductMealPlanEventPayload from(ProductMealPlan mealPlan) {
+        return new ProductMealPlanEventPayload(
+                mealPlan.getId(),
+                mealPlan.getDayOfWeek(),
+                mealPlan.getMenuName(),
+                mealPlan.getAllergyInfo(),
+                mealPlan.getNutritionInfo()
+        );
+    }
+}

--- a/src/main/java/com/ezmeal/product/domain/event/payload/ProductUpdatedEvent.java
+++ b/src/main/java/com/ezmeal/product/domain/event/payload/ProductUpdatedEvent.java
@@ -1,0 +1,43 @@
+package com.ezmeal.product.domain.event.payload;
+
+import com.ezmeal.product.domain.event.ProductEventType;
+import com.ezmeal.product.domain.model.ProductCategory;
+import com.ezmeal.product.domain.model.ProductMealPeriod;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ProductUpdatedEvent {
+
+    private UUID eventId;
+    private ProductEventType productEventType;
+    private OffsetDateTime occurredAt;
+    private UUID productId;
+    private UUID companyId;
+    private String productName;
+    private String productDescription;
+    private Integer price;
+    private ProductCategory category;
+    private ProductMealPeriod mealPeriod;
+    private Integer maxOrderCount;
+    private List<ProductMealPlanEventPayload> mealPlans;
+
+    public static ProductUpdatedEvent of(UUID productId, UUID companyId, String productName, String productDescription,
+                                         Integer price,
+                                         ProductCategory category, ProductMealPeriod mealPeriod, Integer maxOrderCount,
+                                         List<ProductMealPlanEventPayload> mealPlans
+    ) {
+        return new ProductUpdatedEvent(UUID.randomUUID(),
+                ProductEventType.PRODUCT_UPDATED,
+                OffsetDateTime.now(), productId, companyId, productName, productDescription, price, category,
+                mealPeriod,
+                maxOrderCount, mealPlans);
+    }
+}

--- a/src/main/java/com/ezmeal/product/infrastruture/message/kafka/producer/ProductEventProducerImpl.java
+++ b/src/main/java/com/ezmeal/product/infrastruture/message/kafka/producer/ProductEventProducerImpl.java
@@ -1,0 +1,70 @@
+package com.ezmeal.product.infrastruture.message.kafka.producer;
+
+import com.ezmeal.product.domain.event.ProductEventProducer;
+import com.ezmeal.product.domain.event.payload.ProductCreatedEvent;
+import com.ezmeal.product.domain.event.payload.ProductDeletedEvent;
+import com.ezmeal.product.domain.event.payload.ProductUpdatedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+
+// 인증 인가 완료되면 밑에 인증정보 관련 로직 주석 해제 예정
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProductEventProducerImpl implements ProductEventProducer {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Override
+    public void publishCreatedEvent(ProductCreatedEvent event) {
+        // 헤더와 페이로드를 함께 담아서 보내는 sendWithHeaders를 사용
+        sendWithHeaders("product.created", event);
+    }
+
+    @Override
+    public void publishUpdatedEvent(ProductUpdatedEvent event) {
+// 헤더와 페이로드를 함께 담아서 보내는 sendWithHeaders를 사용
+        sendWithHeaders("product.updated", event);
+    }
+
+    @Override
+    public void publishDeletedEvent(ProductDeletedEvent event) {
+// 헤더와 페이로드를 함께 담아서 보내는 sendWithHeaders를 사용
+        sendWithHeaders("product.deleted", event);
+    }
+
+    // 카프카 이벤트 헤더에 사용자 점보를 담는 메서드
+    private void sendWithHeaders(String topic, Object payload) {
+        // 1. 토픽과 데이터(Payload)를 담은 레코드 생성
+        ProducerRecord<String, Object> record = new ProducerRecord<>(topic, payload);
+
+        // 2. 현재 스레드의 인증 정보(SecurityContext)를 가져옴
+        //Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+        // 3. 인증 정보가 있는 유저의 요청일 경우에만 카프카 헤더 추가
+//        if (auth != null && auth.isAuthenticated() && auth.getPrincipal() instanceof CustomUserPrincipal principal) {
+//            record.headers().add("X-User-Id", principal.getUserId().getBytes(StandardCharsets.UTF_8));
+//            record.headers().add("X-User-Role", principal.getRole().name().getBytes(StandardCharsets.UTF_8));
+//        }
+
+        // 4. 카프카로 전송
+        kafkaTemplate.send(record)
+                .whenComplete((result, ex) -> {
+                    if (ex != null) {
+                        log.error("Kafka 이벤트 발행 실패. topic={}", topic, ex);
+                        return;
+                    }
+
+                    log.debug(
+                            "Kafka 이벤트 발행 성공. topic={}, partition={}, offset={}",
+                            result.getRecordMetadata().topic(),
+                            result.getRecordMetadata().partition(),
+                            result.getRecordMetadata().offset()
+                    );
+                });
+    }
+}


### PR DESCRIPTION
## 🔗 Issue Number
- close #10 
## 📝 작업 내역

- [ ] Product(Created/Updated/deleted)event 생성 
- [ ] ProductEventProducer / Impl 생성
- [ ] ProductKafkaListener 생성
- [ ] 서비스 생성/수정/삭제 로직에 이벤트 발행(서버 내부) 추가

## 💡 PR 특이사항

-생성/수정/삭제 시 이벤트를 직접 kafka에 보내면 트랜잭션이 롤백되었을경우 되돌릴 방법이 없어 ApplicationEventPubliser를 사용해 서버 내부 이벤트로 발행시키고 그 이벤트를 트랜잭션이 끝나면 kafka로 넘겨줘서 발행
-consumer까지 할려고 했으나 생각해보니 company쪽 스냅샷과 배송관련 정보들을 payload에 넣지 않아 먼저 구현하고 다시 consumer구현 예정

## 💡 명세서 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 상품 생성, 수정, 삭제 시 이벤트 발행 기능 추가로 다른 시스템과의 통합 강화

* **의존성 업데이트**
  * `com.ezmeal:common` 모듈 버전 업그레이드 (0.0.4 → 0.0.5)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->