### PR TITLE
FEATURE/product/saga-Consumer-구현

### DIFF
--- a/src/main/java/com/ezmeal/product/application/message/OrderCancelledMessage.java
+++ b/src/main/java/com/ezmeal/product/application/message/OrderCancelledMessage.java
@@ -1,0 +1,10 @@
+package com.ezmeal.product.application.message;
+
+import java.util.UUID;
+
+public record OrderCancelledMessage(
+        UUID productId,
+        UUID orderId,
+        Integer quantity
+) {
+}

--- a/src/main/java/com/ezmeal/product/application/request/ProductOrderCountRequest.java
+++ b/src/main/java/com/ezmeal/product/application/request/ProductOrderCountRequest.java
@@ -1,6 +1,9 @@
 package com.ezmeal.product.application.request;
 
+import java.util.UUID;
+
 public record ProductOrderCountRequest(
+        UUID orderId,
         Integer quantity
 ) {
 }

--- a/src/main/java/com/ezmeal/product/application/service/ProductService.java
+++ b/src/main/java/com/ezmeal/product/application/service/ProductService.java
@@ -179,6 +179,10 @@ public class ProductService {
         Product product = productRepository.findByIdAndDeletedAtIsNullForUpdate(productId)
                 .orElseThrow(() -> new CustomException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
+        if (productReservationRepository.existsByOrderIdAndProductId(orderId, productId)) {
+            return;
+        }
+
         if (product.getMaxOrderCount() < quantity) {
             throw new CustomException(ProductErrorCode.PRODUCT_ORDER_QUANTITY_EXCEEDED);
         }
@@ -195,7 +199,8 @@ public class ProductService {
     public void restoreReservedQuantity(UUID productId, UUID orderId) {
         validateReservationRequest(orderId);
 
-        ProductReservation reservation = productReservationRepository.findByOrderIdAndProductId(orderId, productId)
+        ProductReservation reservation = productReservationRepository
+                .findByOrderIdAndProductIdForUpdate(orderId, productId)
                 .orElseThrow(() -> new CustomException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
         if (reservation.isRestored()) {

--- a/src/main/java/com/ezmeal/product/application/service/ProductService.java
+++ b/src/main/java/com/ezmeal/product/application/service/ProductService.java
@@ -15,8 +15,10 @@ import com.ezmeal.product.domain.exception.ProductErrorCode;
 import com.ezmeal.product.domain.model.companySnapShot.CompanySnapshot;
 import com.ezmeal.product.domain.model.product.Product;
 import com.ezmeal.product.domain.model.product.ProductMealPlan;
+import com.ezmeal.product.domain.model.productReservation.ProductReservation;
 import com.ezmeal.product.domain.repository.companySnapshot.CompanySnapshotRepository;
 import com.ezmeal.product.domain.repository.product.ProductRepository;
+import com.ezmeal.product.domain.repository.productReservation.ProductReservationRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -31,6 +33,7 @@ public class ProductService {
     private final ProductRepository productRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
     private final CompanySnapshotRepository companySnapshotRepository;
+    private final ProductReservationRepository productReservationRepository;
 
     //상품 생성
     @Transactional
@@ -164,19 +167,49 @@ public class ProductService {
     }
 
     @Transactional
-    public void reserveOrderQuantity(UUID productId, Integer quantity) {
+    public void reserveOrderQuantity(UUID productId, UUID orderId, Integer quantity) {
+
+        validateReservationRequest(orderId);
+        validateOrderQuantity(quantity);
+
+        if (productReservationRepository.existsByOrderIdAndProductId(orderId, productId)) {
+            return;
+        }
+
         Product product = productRepository.findByIdAndDeletedAtIsNullForUpdate(productId)
                 .orElseThrow(() -> new CustomException(ProductErrorCode.PRODUCT_NOT_FOUND));
-
-        validateOrderQuantity(quantity);
 
         if (product.getMaxOrderCount() < quantity) {
             throw new CustomException(ProductErrorCode.PRODUCT_ORDER_QUANTITY_EXCEEDED);
         }
 
         product.reserveOrderQuantity(quantity);
+
+        productReservationRepository.save(
+                new ProductReservation(orderId, productId, quantity)
+        );
+
     }
 
+    @Transactional
+    public void restoreReservedQuantity(UUID productId, UUID orderId) {
+        validateReservationRequest(orderId);
+
+        ProductReservation reservation = productReservationRepository.findByOrderIdAndProductId(orderId, productId)
+                .orElseThrow(() -> new CustomException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        if (reservation.isRestored()) {
+            return;
+        }
+
+        Product product = productRepository.findByIdAndDeletedAtIsNullForUpdate(productId)
+                .orElseThrow(() -> new CustomException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        product.restoreOrderQuantity(reservation.getQuantity());
+        reservation.restore();
+    }
+
+    //api 테스트용
     @Transactional
     public void restoreOrderQuantity(UUID productId, Integer quantity) {
         Product product = productRepository.findByIdAndDeletedAtIsNullForUpdate(productId)
@@ -190,6 +223,12 @@ public class ProductService {
     private void validateOrderQuantity(Integer quantity) {
         if (quantity == null || quantity <= 0) {
             throw new CustomException(ProductErrorCode.PRODUCT_ORDER_QUANTITY_INVALID);
+        }
+    }
+
+    private void validateReservationRequest(UUID orderId) {
+        if (orderId == null) {
+            throw new CustomException(ProductErrorCode.PRODUCT_INVALID_REQUEST);
         }
     }
 

--- a/src/main/java/com/ezmeal/product/domain/model/productReservation/ProductReservation.java
+++ b/src/main/java/com/ezmeal/product/domain/model/productReservation/ProductReservation.java
@@ -1,0 +1,69 @@
+package com.ezmeal.product.domain.model.productReservation;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "product_reservation", uniqueConstraints = {
+        @UniqueConstraint(
+                name = "uk_product_reservation_order_product",
+                columnNames = {"order_id", "product_id"}
+        )
+})
+public class ProductReservation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "order_id", nullable = false)
+    private UUID orderId;
+
+    @Column(name = "product_id", nullable = false)
+    private UUID productId;
+
+    @Column(nullable = false)
+    private Integer quantity;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ProductReservationStatus status;
+
+    @Column(name = "restored_at")
+    private LocalDateTime restoredAt;
+
+    public ProductReservation(UUID orderId, UUID productId, Integer quantity) {
+        this.orderId = orderId;
+        this.productId = productId;
+        this.quantity = quantity;
+        this.status = ProductReservationStatus.RESERVED;
+    }
+
+    public void restore() {
+        this.status = ProductReservationStatus.RESTORED;
+        this.restoredAt = LocalDateTime.now();
+    }
+
+    public boolean isRestored() {
+        return this.status == ProductReservationStatus.RESTORED;
+    }
+
+    public boolean isReserved() {
+        return this.status == ProductReservationStatus.RESERVED;
+    }
+}

--- a/src/main/java/com/ezmeal/product/domain/model/productReservation/ProductReservationStatus.java
+++ b/src/main/java/com/ezmeal/product/domain/model/productReservation/ProductReservationStatus.java
@@ -1,0 +1,6 @@
+package com.ezmeal.product.domain.model.productReservation;
+
+public enum ProductReservationStatus {
+    RESERVED,
+    RESTORED
+}

--- a/src/main/java/com/ezmeal/product/domain/repository/productReservation/ProductReservationRepository.java
+++ b/src/main/java/com/ezmeal/product/domain/repository/productReservation/ProductReservationRepository.java
@@ -9,4 +9,6 @@ public interface ProductReservationRepository {
     ProductReservation save(ProductReservation productReservation);
     Optional<ProductReservation> findByOrderIdAndProductId(UUID orderId, UUID productId);
     boolean existsByOrderIdAndProductId(UUID orderId, UUID productId);
+
+    Optional<ProductReservation> findByOrderIdAndProductIdForUpdate(UUID orderId, UUID productId);
 }

--- a/src/main/java/com/ezmeal/product/domain/repository/productReservation/ProductReservationRepository.java
+++ b/src/main/java/com/ezmeal/product/domain/repository/productReservation/ProductReservationRepository.java
@@ -1,0 +1,12 @@
+package com.ezmeal.product.domain.repository.productReservation;
+
+import com.ezmeal.product.domain.model.productReservation.ProductReservation;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ProductReservationRepository {
+
+    ProductReservation save(ProductReservation productReservation);
+    Optional<ProductReservation> findByOrderIdAndProductId(UUID orderId, UUID productId);
+    boolean existsByOrderIdAndProductId(UUID orderId, UUID productId);
+}

--- a/src/main/java/com/ezmeal/product/infrastruture/message/kafka/consumer/OrderEventConsumer.java
+++ b/src/main/java/com/ezmeal/product/infrastruture/message/kafka/consumer/OrderEventConsumer.java
@@ -1,0 +1,36 @@
+package com.ezmeal.product.infrastruture.message.kafka.consumer;
+
+import com.ezmeal.product.application.message.OrderCancelledMessage;
+import com.ezmeal.product.application.service.ProductService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderEventConsumer {
+
+    private final ProductService productService;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(topics = "order.cancelled", groupId = "product-group")
+    public void handleOrderCancelled(String payload) {
+        try {
+            OrderCancelledMessage message =
+                    objectMapper.readValue(payload, OrderCancelledMessage.class);
+
+            log.info("[Kafka] order.cancelled 수신. productId={}, orderId={},quantity={}",
+                    message.productId(),
+                    message.orderId(),
+                    message.quantity());
+
+            productService.restoreReservedQuantity(message.productId(),message.orderId());
+        } catch (JsonProcessingException e) {
+            log.error("[Kafka] order.cancelled 메시지 파싱 실패. payload={}", payload, e);
+        }
+    }
+}

--- a/src/main/java/com/ezmeal/product/infrastruture/persistence/productReservationRepository/JpaProductReservationRepository.java
+++ b/src/main/java/com/ezmeal/product/infrastruture/persistence/productReservationRepository/JpaProductReservationRepository.java
@@ -1,0 +1,12 @@
+package com.ezmeal.product.infrastruture.persistence.productReservationRepository;
+
+import com.ezmeal.product.domain.model.productReservation.ProductReservation;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaProductReservationRepository extends JpaRepository<ProductReservation, UUID> {
+
+    Optional<ProductReservation> findByOrderIdAndProductId(UUID orderId, UUID productId);
+    boolean existsByOrderIdAndProductId(UUID orderId, UUID productId);
+}

--- a/src/main/java/com/ezmeal/product/infrastruture/persistence/productReservationRepository/JpaProductReservationRepository.java
+++ b/src/main/java/com/ezmeal/product/infrastruture/persistence/productReservationRepository/JpaProductReservationRepository.java
@@ -1,12 +1,24 @@
 package com.ezmeal.product.infrastruture.persistence.productReservationRepository;
 
 import com.ezmeal.product.domain.model.productReservation.ProductReservation;
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 public interface JpaProductReservationRepository extends JpaRepository<ProductReservation, UUID> {
 
     Optional<ProductReservation> findByOrderIdAndProductId(UUID orderId, UUID productId);
     boolean existsByOrderIdAndProductId(UUID orderId, UUID productId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        select pr
+        from ProductReservation pr
+        where pr.orderId = :orderId
+          and pr.productId = :productId
+        """)
+    Optional<ProductReservation> findByOrderIdAndProductIdForUpdate(UUID orderId, UUID productId);
 }

--- a/src/main/java/com/ezmeal/product/infrastruture/persistence/productReservationRepository/ProductReservationRepositoryImpl.java
+++ b/src/main/java/com/ezmeal/product/infrastruture/persistence/productReservationRepository/ProductReservationRepositoryImpl.java
@@ -27,4 +27,9 @@ public class ProductReservationRepositoryImpl implements ProductReservationRepos
     public boolean existsByOrderIdAndProductId(UUID orderId, UUID productId) {
         return jpaProductReservationRepository.existsByOrderIdAndProductId(orderId, productId);
     }
+
+    @Override
+    public Optional<ProductReservation> findByOrderIdAndProductIdForUpdate(UUID orderId, UUID productId) {
+        return jpaProductReservationRepository.findByOrderIdAndProductIdForUpdate(orderId, productId);
+    }
 }

--- a/src/main/java/com/ezmeal/product/infrastruture/persistence/productReservationRepository/ProductReservationRepositoryImpl.java
+++ b/src/main/java/com/ezmeal/product/infrastruture/persistence/productReservationRepository/ProductReservationRepositoryImpl.java
@@ -1,0 +1,30 @@
+package com.ezmeal.product.infrastruture.persistence.productReservationRepository;
+
+import com.ezmeal.product.domain.model.productReservation.ProductReservation;
+import com.ezmeal.product.domain.repository.productReservation.ProductReservationRepository;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductReservationRepositoryImpl implements ProductReservationRepository {
+
+    private final JpaProductReservationRepository jpaProductReservationRepository;
+
+    @Override
+    public ProductReservation save(ProductReservation productReservation) {
+        return jpaProductReservationRepository.save(productReservation);
+    }
+
+    @Override
+    public Optional<ProductReservation> findByOrderIdAndProductId(UUID orderId, UUID productId) {
+        return jpaProductReservationRepository.findByOrderIdAndProductId(orderId, productId);
+    }
+
+    @Override
+    public boolean existsByOrderIdAndProductId(UUID orderId, UUID productId) {
+        return jpaProductReservationRepository.existsByOrderIdAndProductId(orderId, productId);
+    }
+}

--- a/src/main/java/com/ezmeal/product/presentation/ProductInternalController.java
+++ b/src/main/java/com/ezmeal/product/presentation/ProductInternalController.java
@@ -24,11 +24,13 @@ public class ProductInternalController {
             @PathVariable UUID productId,
             @RequestBody ProductOrderCountRequest request
     ) {
-        productService.reserveOrderQuantity(productId, request.quantity());
+        productService.reserveOrderQuantity(productId, request.orderId(), request.quantity());
 
         return ResponseEntity.ok(CommonApiResponse.success());
     }
 
+
+    // api 테스트용
     @PostMapping("/{productId}/order-quantity/restore")
     public ResponseEntity<CommonApiResponse<Void>> restoreOrderQuantity(
             @PathVariable UUID productId,


### PR DESCRIPTION
## 🔗 Issue Number
- close #36 

## 📝 작업 내역

- [ ]재고 예약 feign 요청 DTO에 orderId 추가
- [ ]productReservation 엔티티 및 레포지토리 추가
- [ ]재고 예약시 reservation에 orderId+productId 기준으로 저장
- [ ] order.cancelled kafka consumer 추가
- [ ] 주문 취소 이벤트 수신 시 reservation을 기준으로 재고 복구 처리 
- [ ] reservation 상태를 reserved -> restored로 변경하여 중복 복구 방지 

## 💡 PR 특이사항

-
-

## 💡 명세서 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 주문별 상품 재고 예약 및 복구 기능 추가
  * 주문 취소 이벤트 처리 메커니즘 구현

* **버그 수정**
  * 주문 취소 시 상품 재고가 올바르게 복구되도록 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->