### PR TITLE
FEATURE/product/재고복구producer

### DIFF
--- a/http/product.http
+++ b/http/product.http
@@ -1,4 +1,4 @@
-@productId = 03679e65-d7f4-4da6-9c33-f52b21dca834
+@productId = b8e46837-ee7e-4670-829c-7622f54e7821
 @companyId = a2a43d96-902f-4c96-84d2-638173fd93d8
 
 ### 상품 생성
@@ -175,10 +175,11 @@ X-User-Email: other@company.com
 }
 
 ### 상품 수량 테스트 - 차감
-POST http://localhost:19083/internal/products/{{productId}}/order-quantity/reserve
+POST http://localhost:19083/internal/v1/products/{{productId}}/order-quantity/reserve
 Content-Type: application/json
 
 {
+  "orderId": "11111111-1111-1111-1111-111111111111",
   "quantity": 3
 }
 

--- a/src/main/java/com/ezmeal/product/application/event/ProductKafkaListener.java
+++ b/src/main/java/com/ezmeal/product/application/event/ProductKafkaListener.java
@@ -1,9 +1,12 @@
 package com.ezmeal.product.application.event;
 
-import com.ezmeal.product.domain.event.ProductEventProducer;
 import com.ezmeal.product.domain.event.payload.ProductCreatedEvent;
 import com.ezmeal.product.domain.event.payload.ProductDeletedEvent;
+import com.ezmeal.product.domain.event.payload.ProductReservationRestoreFailedEvent;
+import com.ezmeal.product.domain.event.payload.ProductReservationRestoredEvent;
 import com.ezmeal.product.domain.event.payload.ProductUpdatedEvent;
+import com.ezmeal.product.domain.event.producer.ProductEventProducer;
+import com.ezmeal.product.domain.event.producer.ProductReservationEventProducer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -14,6 +17,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class ProductKafkaListener {
 
     private final ProductEventProducer productEventProducer;
+    private final ProductReservationEventProducer productReservationEventProducer;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleProductCreatedEvent(ProductCreatedEvent event) {
@@ -30,6 +34,16 @@ public class ProductKafkaListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleProductDeletedEvent(ProductDeletedEvent event) {
         productEventProducer.publishDeletedEvent(event);
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleProductReservationRestoredEvent(ProductReservationRestoredEvent event) {
+        productReservationEventProducer.publishRestoredEvent(event);
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleProductReservationRestoreEventFailed(ProductReservationRestoreFailedEvent event) {
+        productReservationEventProducer.publishRestoreFailedEvent(event);
     }
 
 }

--- a/src/main/java/com/ezmeal/product/application/request/ProductOrderCountRequest.java
+++ b/src/main/java/com/ezmeal/product/application/request/ProductOrderCountRequest.java
@@ -1,9 +1,10 @@
 package com.ezmeal.product.application.request;
 
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 
 public record ProductOrderCountRequest(
-        UUID orderId,
-        Integer quantity
+        @NotNull UUID orderId,
+        @NotNull Integer quantity
 ) {
 }

--- a/src/main/java/com/ezmeal/product/application/service/ProductService.java
+++ b/src/main/java/com/ezmeal/product/application/service/ProductService.java
@@ -10,6 +10,7 @@ import com.ezmeal.product.application.response.ProductResponse;
 import com.ezmeal.product.domain.event.payload.ProductCreatedEvent;
 import com.ezmeal.product.domain.event.payload.ProductDeletedEvent;
 import com.ezmeal.product.domain.event.payload.ProductMealPlanEventPayload;
+import com.ezmeal.product.domain.event.payload.ProductReservationRestoredEvent;
 import com.ezmeal.product.domain.event.payload.ProductUpdatedEvent;
 import com.ezmeal.product.domain.exception.ProductErrorCode;
 import com.ezmeal.product.domain.model.companySnapShot.CompanySnapshot;
@@ -212,6 +213,11 @@ public class ProductService {
 
         product.restoreOrderQuantity(reservation.getQuantity());
         reservation.restore();
+
+        ProductReservationRestoredEvent event = ProductReservationRestoredEvent.of(reservation.getOrderId(),
+                reservation.getProductId(), reservation.getQuantity());
+        applicationEventPublisher.publishEvent(event);
+
     }
 
     //api 테스트용

--- a/src/main/java/com/ezmeal/product/domain/event/payload/ProductCreatedEvent.java
+++ b/src/main/java/com/ezmeal/product/domain/event/payload/ProductCreatedEvent.java
@@ -1,6 +1,5 @@
 package com.ezmeal.product.domain.event.payload;
 
-import com.ezmeal.product.domain.event.ProductEventType;
 import com.ezmeal.product.domain.model.product.ProductCategory;
 import com.ezmeal.product.domain.model.product.ProductMealPeriod;
 import java.time.LocalDateTime;

--- a/src/main/java/com/ezmeal/product/domain/event/payload/ProductEventType.java
+++ b/src/main/java/com/ezmeal/product/domain/event/payload/ProductEventType.java
@@ -1,4 +1,4 @@
-package com.ezmeal.product.domain.event;
+package com.ezmeal.product.domain.event.payload;
 
 public enum ProductEventType {
     PRODUCT_CREATED,

--- a/src/main/java/com/ezmeal/product/domain/event/payload/ProductReservationRestoreFailedEvent.java
+++ b/src/main/java/com/ezmeal/product/domain/event/payload/ProductReservationRestoreFailedEvent.java
@@ -10,18 +10,20 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class ProductDeletedEvent {
-
+public class ProductReservationRestoreFailedEvent {
     private UUID eventId;
-    private ProductEventType productEventType;
     private OffsetDateTime occurredAt;
+    private UUID orderId;
     private UUID productId;
-    private UUID companyId;
+    private String reason;
 
-    public static ProductDeletedEvent of(UUID productId, UUID companyId
-    ) {
-        return new ProductDeletedEvent(UUID.randomUUID(),
-                ProductEventType.PRODUCT_DELETED,
-                OffsetDateTime.now(), productId, companyId);
+    public static ProductReservationRestoreFailedEvent of(UUID orderId, UUID productId, String reason) {
+        return new ProductReservationRestoreFailedEvent(
+                UUID.randomUUID(),
+                OffsetDateTime.now(),
+                orderId,
+                productId,
+                reason
+        );
     }
 }

--- a/src/main/java/com/ezmeal/product/domain/event/payload/ProductReservationRestoredEvent.java
+++ b/src/main/java/com/ezmeal/product/domain/event/payload/ProductReservationRestoredEvent.java
@@ -10,18 +10,20 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class ProductDeletedEvent {
-
+public class ProductReservationRestoredEvent {
     private UUID eventId;
-    private ProductEventType productEventType;
     private OffsetDateTime occurredAt;
+    private UUID orderId;
     private UUID productId;
-    private UUID companyId;
+    private Integer quantity;
 
-    public static ProductDeletedEvent of(UUID productId, UUID companyId
-    ) {
-        return new ProductDeletedEvent(UUID.randomUUID(),
-                ProductEventType.PRODUCT_DELETED,
-                OffsetDateTime.now(), productId, companyId);
+    public static ProductReservationRestoredEvent of(UUID orderId, UUID productId, Integer quantity) {
+        return new ProductReservationRestoredEvent(
+                UUID.randomUUID(),
+                OffsetDateTime.now(),
+                orderId,
+                productId,
+                quantity
+        );
     }
 }

--- a/src/main/java/com/ezmeal/product/domain/event/payload/ProductUpdatedEvent.java
+++ b/src/main/java/com/ezmeal/product/domain/event/payload/ProductUpdatedEvent.java
@@ -1,6 +1,5 @@
 package com.ezmeal.product.domain.event.payload;
 
-import com.ezmeal.product.domain.event.ProductEventType;
 import com.ezmeal.product.domain.model.product.ProductCategory;
 import com.ezmeal.product.domain.model.product.ProductMealPeriod;
 import java.time.LocalDateTime;

--- a/src/main/java/com/ezmeal/product/domain/event/producer/ProductEventProducer.java
+++ b/src/main/java/com/ezmeal/product/domain/event/producer/ProductEventProducer.java
@@ -1,4 +1,4 @@
-package com.ezmeal.product.domain.event;
+package com.ezmeal.product.domain.event.producer;
 
 import com.ezmeal.product.domain.event.payload.ProductCreatedEvent;
 import com.ezmeal.product.domain.event.payload.ProductDeletedEvent;

--- a/src/main/java/com/ezmeal/product/domain/event/producer/ProductReservationEventProducer.java
+++ b/src/main/java/com/ezmeal/product/domain/event/producer/ProductReservationEventProducer.java
@@ -1,0 +1,10 @@
+package com.ezmeal.product.domain.event.producer;
+
+import com.ezmeal.product.domain.event.payload.ProductReservationRestoreFailedEvent;
+import com.ezmeal.product.domain.event.payload.ProductReservationRestoredEvent;
+
+public interface ProductReservationEventProducer {
+    void publishRestoredEvent(ProductReservationRestoredEvent event);
+
+    void publishRestoreFailedEvent(ProductReservationRestoreFailedEvent event);
+}

--- a/src/main/java/com/ezmeal/product/infrastruture/message/kafka/consumer/OrderEventConsumer.java
+++ b/src/main/java/com/ezmeal/product/infrastruture/message/kafka/consumer/OrderEventConsumer.java
@@ -31,6 +31,7 @@ public class OrderEventConsumer {
             productService.restoreReservedQuantity(message.productId(),message.orderId());
         } catch (JsonProcessingException e) {
             log.error("[Kafka] order.cancelled 메시지 파싱 실패. payload={}", payload, e);
+            throw new IllegalArgumentException("order.cancelled 메시지 파싱 실패", e);
         }
     }
 }

--- a/src/main/java/com/ezmeal/product/infrastruture/message/kafka/producer/KafkaEventSender.java
+++ b/src/main/java/com/ezmeal/product/infrastruture/message/kafka/producer/KafkaEventSender.java
@@ -1,0 +1,47 @@
+package com.ezmeal.product.infrastruture.message.kafka.producer;
+
+import com.ezmeal.common.security.principal.CustomUserPrincipal;
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaEventSender {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    public void send(String topic, Object payload) {
+        ProducerRecord<String, Object> record = new ProducerRecord<>(topic, payload);
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+        if (auth != null && auth.isAuthenticated()
+                && auth.getPrincipal() instanceof CustomUserPrincipal principal) {
+            record.headers().add("X-User-Id", principal.getUserId().getBytes(StandardCharsets.UTF_8));
+            record.headers().add("X-User-Roles", principal.getRole().name().getBytes(StandardCharsets.UTF_8));
+
+            String email = principal.getEmail() != null ? principal.getEmail() : "";
+            record.headers().add("X-User-Email", email.getBytes(StandardCharsets.UTF_8));
+        }
+
+        kafkaTemplate.send(record)
+                .whenComplete((result, ex) -> {
+                    if (ex != null) {
+                        log.error("Kafka 이벤트 발행 실패. topic={}", topic, ex);
+                        return;
+                    }
+
+                    log.debug("Kafka 이벤트 발행 성공. topic={}, partition={}, offset={}",
+                            result.getRecordMetadata().topic(),
+                            result.getRecordMetadata().partition(),
+                            result.getRecordMetadata().offset());
+                });
+    }
+}

--- a/src/main/java/com/ezmeal/product/infrastruture/message/kafka/producer/ProductEventProducerImpl.java
+++ b/src/main/java/com/ezmeal/product/infrastruture/message/kafka/producer/ProductEventProducerImpl.java
@@ -1,17 +1,11 @@
 package com.ezmeal.product.infrastruture.message.kafka.producer;
 
-import com.ezmeal.common.security.principal.CustomUserPrincipal;
-import com.ezmeal.product.domain.event.producer.ProductEventProducer;
 import com.ezmeal.product.domain.event.payload.ProductCreatedEvent;
 import com.ezmeal.product.domain.event.payload.ProductDeletedEvent;
 import com.ezmeal.product.domain.event.payload.ProductUpdatedEvent;
-import java.nio.charset.StandardCharsets;
+import com.ezmeal.product.domain.event.producer.ProductEventProducer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.kafka.clients.producer.ProducerRecord;
-import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 
@@ -20,57 +14,24 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ProductEventProducerImpl implements ProductEventProducer {
 
-    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final KafkaEventSender kafkaEventSender;
 
     @Override
     public void publishCreatedEvent(ProductCreatedEvent event) {
-        // 헤더와 페이로드를 함께 담아서 보내는 sendWithHeaders를 사용
-        sendWithHeaders("product.created", event);
+        // 헤더와 페이로드를 함께 담아서 보내는 kafkaEventSender.send를 사용
+        kafkaEventSender.send("product.created", event);
     }
 
     @Override
     public void publishUpdatedEvent(ProductUpdatedEvent event) {
-// 헤더와 페이로드를 함께 담아서 보내는 sendWithHeaders를 사용
-        sendWithHeaders("product.updated", event);
+// 헤더와 페이로드를 함께 담아서 보내는 kafkaEventSender.send를 사용
+        kafkaEventSender.send("product.updated", event);
     }
 
     @Override
     public void publishDeletedEvent(ProductDeletedEvent event) {
-// 헤더와 페이로드를 함께 담아서 보내는 sendWithHeaders를 사용
-        sendWithHeaders("product.deleted", event);
+// 헤더와 페이로드를 함께 담아서 보내는 kafkaEventSender.send를 사용
+        kafkaEventSender.send("product.deleted", event);
     }
 
-    // 카프카 이벤트 헤더에 사용자 점보를 담는 메서드
-    private void sendWithHeaders(String topic, Object payload) {
-        // 1. 토픽과 데이터(Payload)를 담은 레코드 생성
-        ProducerRecord<String, Object> record = new ProducerRecord<>(topic, payload);
-
-        // 2. 현재 스레드의 인증 정보(SecurityContext)를 가져옴
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-
-        // 3. 인증 정보가 있는 유저의 요청일 경우에만 카프카 헤더 추가
-        if (auth != null && auth.isAuthenticated() && auth.getPrincipal() instanceof CustomUserPrincipal principal) {
-            record.headers().add("X-User-Id", principal.getUserId().getBytes(StandardCharsets.UTF_8));
-            record.headers().add("X-User-Roles", principal.getRole().name().getBytes(StandardCharsets.UTF_8));
-
-            String email = principal.getEmail() != null ? principal.getEmail() : "";
-            record.headers().add("X-User-Email", email.getBytes(StandardCharsets.UTF_8));
-        }
-
-        // 4. 카프카로 전송
-        kafkaTemplate.send(record)
-                .whenComplete((result, ex) -> {
-                    if (ex != null) {
-                        log.error("Kafka 이벤트 발행 실패. topic={}", topic, ex);
-                        return;
-                    }
-
-                    log.debug(
-                            "Kafka 이벤트 발행 성공. topic={}, partition={}, offset={}",
-                            result.getRecordMetadata().topic(),
-                            result.getRecordMetadata().partition(),
-                            result.getRecordMetadata().offset()
-                    );
-                });
-    }
 }

--- a/src/main/java/com/ezmeal/product/infrastruture/message/kafka/producer/ProductReservationEventProducerImpl.java
+++ b/src/main/java/com/ezmeal/product/infrastruture/message/kafka/producer/ProductReservationEventProducerImpl.java
@@ -1,10 +1,9 @@
 package com.ezmeal.product.infrastruture.message.kafka.producer;
 
 import com.ezmeal.common.security.principal.CustomUserPrincipal;
-import com.ezmeal.product.domain.event.producer.ProductEventProducer;
-import com.ezmeal.product.domain.event.payload.ProductCreatedEvent;
-import com.ezmeal.product.domain.event.payload.ProductDeletedEvent;
-import com.ezmeal.product.domain.event.payload.ProductUpdatedEvent;
+import com.ezmeal.product.domain.event.payload.ProductReservationRestoreFailedEvent;
+import com.ezmeal.product.domain.event.payload.ProductReservationRestoredEvent;
+import com.ezmeal.product.domain.event.producer.ProductReservationEventProducer;
 import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,30 +13,21 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
-
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class ProductEventProducerImpl implements ProductEventProducer {
+public class ProductReservationEventProducerImpl implements ProductReservationEventProducer {
 
     private final KafkaTemplate<String, Object> kafkaTemplate;
 
     @Override
-    public void publishCreatedEvent(ProductCreatedEvent event) {
-        // 헤더와 페이로드를 함께 담아서 보내는 sendWithHeaders를 사용
-        sendWithHeaders("product.created", event);
+    public void publishRestoredEvent(ProductReservationRestoredEvent event) {
+        sendWithHeaders("product.quantity.restored", event);
     }
 
     @Override
-    public void publishUpdatedEvent(ProductUpdatedEvent event) {
-// 헤더와 페이로드를 함께 담아서 보내는 sendWithHeaders를 사용
-        sendWithHeaders("product.updated", event);
-    }
-
-    @Override
-    public void publishDeletedEvent(ProductDeletedEvent event) {
-// 헤더와 페이로드를 함께 담아서 보내는 sendWithHeaders를 사용
-        sendWithHeaders("product.deleted", event);
+    public void publishRestoreFailedEvent(ProductReservationRestoreFailedEvent event) {
+        sendWithHeaders("product.quantity.restore.failed", event);
     }
 
     // 카프카 이벤트 헤더에 사용자 점보를 담는 메서드

--- a/src/main/java/com/ezmeal/product/infrastruture/message/kafka/producer/ProductReservationEventProducerImpl.java
+++ b/src/main/java/com/ezmeal/product/infrastruture/message/kafka/producer/ProductReservationEventProducerImpl.java
@@ -1,16 +1,10 @@
 package com.ezmeal.product.infrastruture.message.kafka.producer;
 
-import com.ezmeal.common.security.principal.CustomUserPrincipal;
 import com.ezmeal.product.domain.event.payload.ProductReservationRestoreFailedEvent;
 import com.ezmeal.product.domain.event.payload.ProductReservationRestoredEvent;
 import com.ezmeal.product.domain.event.producer.ProductReservationEventProducer;
-import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.kafka.clients.producer.ProducerRecord;
-import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -18,49 +12,16 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ProductReservationEventProducerImpl implements ProductReservationEventProducer {
 
-    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final KafkaEventSender kafkaEventSender;
 
     @Override
     public void publishRestoredEvent(ProductReservationRestoredEvent event) {
-        sendWithHeaders("product.quantity.restored", event);
+        kafkaEventSender.send("product.quantity.restored", event);
     }
 
     @Override
     public void publishRestoreFailedEvent(ProductReservationRestoreFailedEvent event) {
-        sendWithHeaders("product.quantity.restore.failed", event);
+        kafkaEventSender.send("product.quantity.restore.failed", event);
     }
 
-    // 카프카 이벤트 헤더에 사용자 점보를 담는 메서드
-    private void sendWithHeaders(String topic, Object payload) {
-        // 1. 토픽과 데이터(Payload)를 담은 레코드 생성
-        ProducerRecord<String, Object> record = new ProducerRecord<>(topic, payload);
-
-        // 2. 현재 스레드의 인증 정보(SecurityContext)를 가져옴
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-
-        // 3. 인증 정보가 있는 유저의 요청일 경우에만 카프카 헤더 추가
-        if (auth != null && auth.isAuthenticated() && auth.getPrincipal() instanceof CustomUserPrincipal principal) {
-            record.headers().add("X-User-Id", principal.getUserId().getBytes(StandardCharsets.UTF_8));
-            record.headers().add("X-User-Roles", principal.getRole().name().getBytes(StandardCharsets.UTF_8));
-
-            String email = principal.getEmail() != null ? principal.getEmail() : "";
-            record.headers().add("X-User-Email", email.getBytes(StandardCharsets.UTF_8));
-        }
-
-        // 4. 카프카로 전송
-        kafkaTemplate.send(record)
-                .whenComplete((result, ex) -> {
-                    if (ex != null) {
-                        log.error("Kafka 이벤트 발행 실패. topic={}", topic, ex);
-                        return;
-                    }
-
-                    log.debug(
-                            "Kafka 이벤트 발행 성공. topic={}, partition={}, offset={}",
-                            result.getRecordMetadata().topic(),
-                            result.getRecordMetadata().partition(),
-                            result.getRecordMetadata().offset()
-                    );
-                });
-    }
 }

--- a/src/main/java/com/ezmeal/product/presentation/ProductInternalController.java
+++ b/src/main/java/com/ezmeal/product/presentation/ProductInternalController.java
@@ -3,6 +3,7 @@ package com.ezmeal.product.presentation;
 import com.ezmeal.common.response.CommonApiResponse;
 import com.ezmeal.product.application.request.ProductOrderCountRequest;
 import com.ezmeal.product.application.service.ProductService;
+import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,7 +23,7 @@ public class ProductInternalController {
     @PostMapping("/{productId}/order-quantity/reserve")
     public ResponseEntity<CommonApiResponse<Void>> reserveOrderQuantity(
             @PathVariable UUID productId,
-            @RequestBody ProductOrderCountRequest request
+            @RequestBody @Valid ProductOrderCountRequest request
     ) {
         productService.reserveOrderQuantity(productId, request.orderId(), request.quantity());
 


### PR DESCRIPTION
## 🔗 Issue Number
- close #38 

## 📝 작업 내역

- [ ] 재고 복구 성공/실패 payload 추가
- [ ] 재고 복구 결과 interface추가 및 구현체 구현
- [ ] 재고 복구 성공 시 내부 이벤트 발행
- [ ] 트랜잭션 커밋 이후 product.quantity.restored 이벤트 발행
- [ ] 

## 💡 PR 특이사항

-product.quantity.restore.failed` payload와 producer 메서드는 추가했지만, 실제 발행은 Kafka retry/DLT 적용 시점에 연결할 예정
- 실패 이벤트는 단일 처리 실패가 아니라 retry/DLT 이후 최종 실패 기준으로 발행하는 방향 입니다

## 💡 명세서 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 상품 예약 복구 이벤트 처리 기능 추가

* **개선사항**
  * 상품 주문 수량 요청에 주문 ID 필드 추가 및 필수 검증 강화
  * 주문 취소 메시지 파싱 실패 시 오류 처리 개선
  * 예약 복구 프로세스에 이벤트 발행 메커니즘 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->