### PR TITLE
FIX/product/검색로그kafka수신및es문서적용후DLT흐름파악

### DIFF
--- a/src/main/java/com/ezmeal/product/application/search/log/ProductSearchLogCommand.java
+++ b/src/main/java/com/ezmeal/product/application/search/log/ProductSearchLogCommand.java
@@ -31,10 +31,10 @@ public record ProductSearchLogCommand(
     public static ProductSearchLogCommand from(ProductSearchLoggedEvent event) {
         return new ProductSearchLogCommand(
                 event.getUserId(),
-                event.getKeyword(),
-                event.getCategory(),
-                event.getMealPeriod(),
-                event.getRegion(),
+                normalize(event.getKeyword()),
+                normalize(event.getCategory()),
+                normalize(event.getMealPeriod()),
+                normalize(event.getRegion()),
                 event.getMinPrice(),
                 event.getMaxPrice(),
                 event.getSearchedAt()

--- a/src/main/java/com/ezmeal/product/application/search/log/ProductSearchLogCommand.java
+++ b/src/main/java/com/ezmeal/product/application/search/log/ProductSearchLogCommand.java
@@ -1,6 +1,7 @@
 package com.ezmeal.product.application.search.log;
 
 import com.ezmeal.product.application.request.ProductSearchRequest;
+import com.ezmeal.product.domain.event.payload.ProductSearchLoggedEvent;
 import java.time.LocalDateTime;
 
 public record ProductSearchLogCommand(
@@ -24,6 +25,19 @@ public record ProductSearchLogCommand(
                 request.minPrice(),
                 request.maxPrice(),
                 LocalDateTime.now()
+        );
+    }
+
+    public static ProductSearchLogCommand from(ProductSearchLoggedEvent event) {
+        return new ProductSearchLogCommand(
+                event.getUserId(),
+                event.getKeyword(),
+                event.getCategory(),
+                event.getMealPeriod(),
+                event.getRegion(),
+                event.getMinPrice(),
+                event.getMaxPrice(),
+                event.getSearchedAt()
         );
     }
 

--- a/src/main/java/com/ezmeal/product/domain/event/producer/ProductEventProducer.java
+++ b/src/main/java/com/ezmeal/product/domain/event/producer/ProductEventProducer.java
@@ -2,7 +2,6 @@ package com.ezmeal.product.domain.event.producer;
 
 import com.ezmeal.product.domain.event.payload.ProductCreatedEvent;
 import com.ezmeal.product.domain.event.payload.ProductDeletedEvent;
-import com.ezmeal.product.domain.event.payload.ProductSearchLoggedEvent;
 import com.ezmeal.product.domain.event.payload.ProductUpdatedEvent;
 
 public interface ProductEventProducer {

--- a/src/main/java/com/ezmeal/product/infrastruture/message/kafka/consumer/ProductSearchLogEventConsumer.java
+++ b/src/main/java/com/ezmeal/product/infrastruture/message/kafka/consumer/ProductSearchLogEventConsumer.java
@@ -1,0 +1,26 @@
+package com.ezmeal.product.infrastruture.message.kafka.consumer;
+
+import com.ezmeal.common.message.EventEnvelope;
+import com.ezmeal.product.application.search.log.ProductSearchLogAppender;
+import com.ezmeal.product.application.search.log.ProductSearchLogCommand;
+import com.ezmeal.product.domain.event.payload.ProductSearchLoggedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProductSearchLogEventConsumer {
+
+    private final ProductSearchLogAppender productSearchLogAppender;
+
+    @KafkaListener(topics = "product.search.logged", groupId = "product-search-log-group")
+    public void handleProductSearchLogged(EventEnvelope<ProductSearchLoggedEvent> envelope) {
+        ProductSearchLoggedEvent payload = envelope.payload();
+
+        ProductSearchLogCommand command = ProductSearchLogCommand.from(payload);
+        productSearchLogAppender.append(command);
+    }
+}

--- a/src/main/java/com/ezmeal/product/infrastruture/message/kafka/producer/ProductEventProducerImpl.java
+++ b/src/main/java/com/ezmeal/product/infrastruture/message/kafka/producer/ProductEventProducerImpl.java
@@ -4,7 +4,6 @@ import com.ezmeal.common.message.CommonKafkaEventPublisher;
 import com.ezmeal.product.domain.event.payload.ProductCreatedEvent;
 import com.ezmeal.product.domain.event.payload.ProductDeletedEvent;
 import com.ezmeal.product.domain.event.payload.ProductEventType;
-import com.ezmeal.product.domain.event.payload.ProductSearchLoggedEvent;
 import com.ezmeal.product.domain.event.payload.ProductUpdatedEvent;
 import com.ezmeal.product.domain.event.producer.ProductEventProducer;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/ezmeal/product/infrastruture/message/kafka/producer/ProductSearchLogEventProducerImpl.java
+++ b/src/main/java/com/ezmeal/product/infrastruture/message/kafka/producer/ProductSearchLogEventProducerImpl.java
@@ -34,13 +34,11 @@ public class ProductSearchLogEventProducerImpl implements ProductSearchLogEventP
             kafkaTemplate.send("product.search.logged", event.getUserId(), payload)
                     .whenComplete((result, ex) -> {
                         if (ex != null) {
-                            log.warn("검색 로그 이벤트 발행 실패. userId={}, keyword={}",
-                                    event.getUserId(), event.getKeyword(), ex);
+                            log.warn("검색 로그 이벤트 발행 실패.", ex);
                         }
                     });
         } catch (JsonProcessingException e) {
-            log.warn("검색 로그 이벤트 직렬화 실패. userId={}, keyword={}",
-                    event.getUserId(), event.getKeyword(), e);
+            log.warn("검색 로그 이벤트 직렬화 실패.", e);
         }
     }
 }


### PR DESCRIPTION
## 🔗 Issue Number
- close #55 

## 📝 작업 내역

- [ ] consumer수신 후 es로그문서에 저장
- [ ] DLT consumer는 따로 만들 필요가 없을거 같음

## 💡 PR 특이사항

- 이제 상품 목록조회시 로그문서에 바로 저장되는 구조를 조회 시 카프카 이벤트를 발행하고 그걸 받아 저장하는 구조로 바꿨으니 부하테스트를 다시 해보고 그래도 느리다면 elasticSerach 쿼리문 특히 keyword쪽을 손볼예정
-

## 💡 명세서 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 검색 로그 수집을 위한 이벤트 소비 처리 기능이 추가되었습니다.

* **Refactor**
  * 이벤트 기반 검색 로깅 처리 흐름이 개선되어 로그 안정성과 처리 분리가 향상되었습니다.
  * 예외 로깅 형식이 단순화되어 불필요한 민감 정보 노출이 줄어들었습니다.

* **Chores**
  * 사용되지 않는 임포트가 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->